### PR TITLE
Implement name entry screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,15 @@
 </head>
 <body>
   <h1>Fixation Game Prototype</h1>
-  <canvas id="gameCanvas"></canvas>
-  <div id="uiContainer"></div>
+  <div id="nameScreen">
+    <h2>Who's Playing?</h2>
+    <label>Black: <input type="text" id="blackName" /></label><br>
+    <label>White: <input type="text" id="whiteName" /></label><br>
+    <button id="startGameBtn">Start Game</button>
+  </div>
+
+  <canvas id="gameCanvas" width="800" height="600" style="display:none;"></canvas>
+  <div id="uiContainer" style="display:none;"></div>
   <script src="script.js" defer></script>
-  <canvas id="gameCanvas" width="800" height="600"></canvas>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,42 @@
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
 const uiContainer = document.getElementById('uiContainer');
+const nameScreen = document.getElementById('nameScreen');
+const startGameBtn = document.getElementById('startGameBtn');
+
+startGameBtn.addEventListener("click", () => {
+  const black = document.getElementById("blackName").value.trim();
+  const white = document.getElementById("whiteName").value.trim();
+
+  if (!black || !white) {
+    alert("Please enter both names.");
+    return;
+  }
+
+  const pairName = (black.slice(0, 2) + white.slice(0, 2)).toLowerCase();
+  playerPair = pairName;
+
+  const savedData = localStorage.getItem(pairName);
+  if (savedData) {
+    playerProfile = JSON.parse(savedData);
+    console.log("Loaded saved profile:", playerProfile);
+  } else {
+    playerProfile = {
+      names: { black, white },
+      discoveredFormulas: [],
+      unlockedElements: [],
+      uses: {}
+    };
+    localStorage.setItem(pairName, JSON.stringify(playerProfile));
+    console.log("Created new profile:", playerProfile);
+  }
+
+  nameScreen.style.display = "none";
+  canvas.style.display = "block";
+  uiContainer.style.display = "block";
+  resizeCanvas();
+  startGame();
+});
 function resizeCanvas() {
   const rect = canvas.getBoundingClientRect();
   canvas.width = rect.width;
@@ -29,6 +65,9 @@ let roundNumber = 1;
 let isFirstMove = true;
 let lastPlayerToPlace = null;
 let lastFormulaClaimedName = null; // Track the last claimed formula name
+
+let playerPair = null;
+let playerProfile = null;
 
 const tileImages = {
   "black1": "https://res.cloudinary.com/dyoqz4zeb/image/upload/v1734648919/Fixation.Black1.1_adrb7w.png",
@@ -71,7 +110,7 @@ function updateBoardOffsets() {
 }
 
 // Initialize board offsets after the helper is defined
-resizeCanvas(); // Run once after offsets are defined
+// (canvas will be resized once players start the game)
 
 const neighborDirs = [
   {q: 1, r: 0},

--- a/style.css
+++ b/style.css
@@ -16,3 +16,12 @@ canvas {
   border: 1px solid #333;
   display: block;
 }
+
+#nameScreen {
+  background: white;
+  padding: 20px;
+  border: 2px solid #333;
+  border-radius: 10px;
+  margin-top: 30px;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- prompt for player names on load and store profiles
- hide game canvas until names entered
- style name entry UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68749b8d07b483328388ed3ad903098c