### PR TITLE
Add in-game menu with save/load

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,28 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <button id="hamburger" aria-label="Menu">&#9776;</button>
+  <div id="menuOverlay" class="hidden">
+    <ul>
+      <li><button id="rulesBtn">Rules</button></li>
+      <li><button id="newGameBtn">New Game</button></li>
+      <li><button id="saveGameBtn">Save Game</button></li>
+      <li><button id="loadGameBtn">Load Game</button></li>
+      <li><button id="techTreeBtn">Tech Tree</button></li>
+    </ul>
+  </div>
+  <div id="rulesModal" class="modal hidden">
+    <div class="modal-content">
+      <p>Rules go here.</p>
+      <button id="closeRules">Close</button>
+    </div>
+  </div>
+  <div id="techTreeModal" class="modal hidden">
+    <div class="modal-content">
+      <p>Tech tree placeholder.</p>
+      <button id="closeTechTree">Close</button>
+    </div>
+  </div>
   <h1>Fixation Game Prototype</h1>
   <div id="nameScreen">
     <h2>Who's Playing?</h2>

--- a/script.js
+++ b/script.js
@@ -13,6 +13,40 @@ document.addEventListener('DOMContentLoaded', () => {
   pairNameDisplay = document.getElementById('pairNameDisplay');
   pairNameSection = document.getElementById('pairNameSection');
 
+  const hamburger = document.getElementById('hamburger');
+  const menuOverlay = document.getElementById('menuOverlay');
+  const rulesModal = document.getElementById('rulesModal');
+  const techTreeModal = document.getElementById('techTreeModal');
+  hamburger.addEventListener('click', () => {
+    menuOverlay.classList.toggle('hidden');
+  });
+  document.getElementById('rulesBtn').addEventListener('click', () => {
+    rulesModal.classList.remove('hidden');
+    menuOverlay.classList.add('hidden');
+  });
+  document.getElementById('techTreeBtn').addEventListener('click', () => {
+    techTreeModal.classList.remove('hidden');
+    menuOverlay.classList.add('hidden');
+  });
+  document.getElementById('closeRules').addEventListener('click', () => {
+    rulesModal.classList.add('hidden');
+  });
+  document.getElementById('closeTechTree').addEventListener('click', () => {
+    techTreeModal.classList.add('hidden');
+  });
+  document.getElementById('newGameBtn').addEventListener('click', () => {
+    menuOverlay.classList.add('hidden');
+    newGame();
+  });
+  document.getElementById('saveGameBtn').addEventListener('click', () => {
+    saveGame();
+    menuOverlay.classList.add('hidden');
+  });
+  document.getElementById('loadGameBtn').addEventListener('click', () => {
+    loadGame();
+    menuOverlay.classList.add('hidden');
+  });
+
   generatePairBtn.addEventListener('click', generatePairName);
   shufflePairBtn.addEventListener('click', shufflePair);
   startGameBtn.addEventListener('click', startGameClicked);
@@ -68,8 +102,17 @@ function startGameClicked() {
 
   const savedData = localStorage.getItem(playerPair);
   if (savedData) {
-    playerProfile = JSON.parse(savedData);
-    console.log("Loaded saved profile:", playerProfile);
+    const data = JSON.parse(savedData);
+    playerProfile = data.profile || {
+      names: { black, white },
+      discoveredFormulas: [],
+      unlockedElements: [],
+      uses: {}
+    };
+    blackScore = data.blackScore || 0;
+    whiteScore = data.whiteScore || 0;
+    roundNumber = data.roundNumber || 1;
+    console.log("Loaded saved profile:", data);
   } else {
     playerProfile = {
       names: { black, white },
@@ -77,7 +120,7 @@ function startGameClicked() {
       unlockedElements: [],
       uses: {}
     };
-    localStorage.setItem(playerPair, JSON.stringify(playerProfile));
+    localStorage.setItem(playerPair, JSON.stringify({profile: playerProfile}));
     console.log("Created new profile:", playerProfile);
   }
 
@@ -565,6 +608,47 @@ function startGame() {
   roundNumber = 1;
   gameState = "turnAnnounce";
   drawUI();
+}
+
+function newGame() {
+  blackScore = 0;
+  whiteScore = 0;
+  for (const key in boardspace) {
+    delete boardspace[key];
+  }
+  isFirstMove = true;
+  selectedTile = null;
+  highlightedSpaces = [];
+  blackHand = [];
+  whiteHand = [];
+  resetStacks();
+  startGame();
+}
+
+function saveGame() {
+  const data = {
+    profile: playerProfile,
+    blackScore,
+    whiteScore,
+    roundNumber
+  };
+  localStorage.setItem(playerPair, JSON.stringify(data));
+  alert('Game saved');
+}
+
+function loadGame() {
+  const saved = localStorage.getItem(playerPair);
+  if (saved) {
+    const data = JSON.parse(saved);
+    if (data.profile) playerProfile = data.profile;
+    blackScore = data.blackScore || 0;
+    whiteScore = data.whiteScore || 0;
+    roundNumber = data.roundNumber || 1;
+    drawUI();
+    alert('Game loaded');
+  } else {
+    alert('No saved data');
+  }
 }
 
 function scoreRound(winnerColor, formulaMatched) {

--- a/style.css
+++ b/style.css
@@ -34,3 +34,59 @@ canvas {
   font-weight: bold;
   margin-right: 10px;
 }
+
+/* --- Menu styles --- */
+.hidden {
+  display: none;
+}
+
+#hamburger {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  background: transparent;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  z-index: 1000;
+}
+
+#menuOverlay {
+  position: absolute;
+  top: 40px;
+  left: 10px;
+  background: white;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 10px;
+  z-index: 999;
+}
+
+#menuOverlay ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+#menuOverlay li {
+  margin-bottom: 5px;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1001;
+}
+
+.modal-content {
+  background: white;
+  padding: 20px;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- add hamburger menu overlay with buttons for rules, new game, saving and loading game data, and a placeholder tech tree
- style the overlay and modals
- implement menu behaviour and persistent save/load logic keyed by pair name

## Testing
- `node -c script.js`
- `node -e "require('./script.js');"` *(fails: document is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68751176e20c8332bcdb503bcf9669f7