### PR TITLE
Add basic tech tree functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       <li><button id="newGameBtn">New Game</button></li>
       <li><button id="saveGameBtn">Save Game</button></li>
       <li><button id="loadGameBtn">Load Game</button></li>
-      <li><button id="techTreeBtn">Tech Tree</button></li>
+      <li><button id="magnumOpusBtn">Magnum Opus</button></li>
     </ul>
   </div>
   <div id="rulesModal" class="modal hidden">
@@ -22,10 +22,18 @@
       <button id="closeRules">Close</button>
     </div>
   </div>
-  <div id="techTreeModal" class="modal hidden">
+  <div id="magnumOpusModal" class="modal hidden">
     <div class="modal-content">
-      <p>Tech tree placeholder.</p>
-      <button id="closeTechTree">Close</button>
+      <h2>The Magnum Opus</h2>
+      <div id="techTreeContainer">
+        <canvas id="techTreeCanvas" width="700" height="500"></canvas>
+        <div id="techTreeInfo">
+          <h3 id="selectedNodeName"></h3>
+          <p id="selectedNodeDescription"></p>
+          <button id="unlockNodeBtn" style="display:none;">Unlock (Cost: <span id="unlockCost"></span> Essence)</button>
+        </div>
+        <button id="closeMagnumOpus">Close</button>
+      </div>
     </div>
   </div>
   <h1>Fixation Game Prototype</h1>

--- a/style.css
+++ b/style.css
@@ -90,3 +90,30 @@ canvas {
   padding: 20px;
   border-radius: 4px;
 }
+
+#magnumOpusModal .modal-content {
+  width: 80%;
+  max-width: 900px;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+#techTreeContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+#techTreeCanvas {
+  border: 1px solid #aaa;
+  background-color: #f0f0f0;
+}
+
+#techTreeInfo {
+  text-align: center;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #e9ecef;
+}


### PR DESCRIPTION
## Summary
- integrate a Magnum Opus modal with a tech tree canvas
- style the modal and tech tree elements
- store essence and unlocked tech tree nodes in save data
- draw and interact with the tech tree canvas
- adjust score logic to grant essence for completed formulas

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68759425e14c833285d483cf44eba1a4