### PR TITLE
Fix tech tree and essence handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
       <h2>The Magnum Opus</h2>
       <div id="techTreeContainer">
         <canvas id="techTreeCanvas" width="700" height="500"></canvas>
+        <div id="essenceDisplay">Essence: <span id="essenceCount">0</span></div>
         <div id="techTreeInfo">
           <h3 id="selectedNodeName"></h3>
           <p id="selectedNodeDescription"></p>

--- a/style.css
+++ b/style.css
@@ -110,6 +110,11 @@ canvas {
   background-color: #f0f0f0;
 }
 
+#essenceDisplay {
+  margin-top: 10px;
+  font-weight: bold;
+}
+
 #techTreeInfo {
   text-align: center;
   padding: 10px;


### PR DESCRIPTION
## Summary
- switch tech tree essence to a shared pool
- initialize tier‑1 nodes as unlocked when starting a game
- update UI to show a single essence total
- allow starting a game via `newGame()` so defaults initialize

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6875ab5cfae48332bd0c5d10a36248fc